### PR TITLE
Boost sortuniq

### DIFF
--- a/sortuniq
+++ b/sortuniq
@@ -2,13 +2,13 @@
 <?php
 $in=fopen('php://stdin',"r");
 $d=array();
-while($z=fgets($in)){
- @$d[$z]++;
-}
+while($z=fgets($in))
+	 @$d[$z]++;
 
 if($argc>1 and ($argv[1]=='c' or $argv[1]=='-c'))
-	foreach($d as $a=>$b)
-		echo ("$b $a");
+{
+        array_walk($d, function(&$a, $b) {$a = "$b $a";});
+        echo implode('', $d);
+}
 else
-	foreach($d as $a=>$b)
-		echo ("$a");
+        echo implode('', array_keys($d));

--- a/sortuniq
+++ b/sortuniq
@@ -5,10 +5,11 @@ $d=array();
 while($z=fgets($in))
 	 @$d[$z]++;
 
+ob_start(null, 100000);
+
 if($argc>1 and ($argv[1]=='c' or $argv[1]=='-c'))
-{
-        array_walk($d, function(&$a, $b) {$a = "$a $b";});
-        echo implode('', $d);
-}
+	foreach($d as $a=>$b)
+		echo "$b $a";
 else
-        echo implode('', array_keys($d));
+	foreach($d as $a=>$b)
+		echo $a;

--- a/sortuniq
+++ b/sortuniq
@@ -7,7 +7,7 @@ while($z=fgets($in))
 
 if($argc>1 and ($argv[1]=='c' or $argv[1]=='-c'))
 {
-        array_walk($d, function(&$a, $b) {$a = "$b $a";});
+        array_walk($d, function(&$a, $b) {$a = "$a $b";});
         echo implode('', $d);
 }
 else


### PR DESCRIPTION
I noticed that my previous benchmarks were a bit optimistic as `fish` (just like `sh` and `zsh`) didn't take echoing into account. The actual times were a bit worse than normal sorts as `sortuniq` spent at least as much time echoing as it needs for sorting.

I tried out various ways like concatenating output in a string before echoing etc. The fastest solution that I found is what I propose in this PR. I will refer to it as `sortuniq2` in this post.

I set up a big random file and also filtered an ascii version.

```
dd if=/dev/urandom of=random_sortable bs=1M count=100 >/dev/null 2>&1
cat random_sortable | tr -dc "\n[:print:]" > ascii_sortable
```

Here are approximate benchmarks for filtering and echoing (I just wrapped the corresponding part of PHP in `$start = microtime(true);` and `$t = microtime(true)-$start; fwrite(STDERR, $time);` and ran it a couple of times).

action | sortuniq random | sortuniq ascii | sortuniq2 random | sortuniq2 ascii
-------|--------------|----------|--------|-----------
filtering | 0.50s | 0.35s | 0.50s | 0.35s
echoing to /dev/null | 0.92s | 0.88s | 0.20s | 0.10s
echoing to file | 2.6s | 2.45s | 0.48s | 0.19s
echoing to /dev/null with -c | 0.93s | 0.90s | 0.40s | 0.20s
echoing to file with -c | 2.65s | 2.50s | 0.67s | 0.28s

I was able to optimize the branch without `-c` a bit more.

I also benchmarked the total time of doing the duplicate deleting in various ways

command                  | random > sorted | ascii > sorted | random > null | ascii > null
-------------------------|-----------------|----------------|---------------|-------------
sort -u sortable  > out | 2.237 | 0.862 | 1.423 | 0.511
sort sortable \| uniq > out | 2.321 | 0.848 | 1.467 | 0.540
sort sortable \| uniq -c > out | 2.445 | 0.933 | 1.502 | 0.593
awk '!x[$0]++;' sortable  > out | 2.416 | 1.301 | 1.522 | 0.915
cat sortable \| sort -u > out | 4.868 | 1.771 | 3.963 | 1.488
cat sortable \| sort \| uniq > out | 4.326 | 1.613 | 3.605 | 1.349
cat sortable \| sort \| uniq -c > out | 4.376 | 1.689 | 3.715 | 1.437
cat sortable \| awk '!x[$0]++;' > out | 2.343 | 1.192 | 1.413 | 0.788
cat sortable \| ./sortuniq > out | 3.283 | 2.883 | 1.486 | 1.285
cat sortable \| ./sortuniq -c > out | 3.233 | 2.957 | 1.524 | 1.281
cat sortable \| ./sortuniq2 > out | 1.062 | 0.583 | 0.789 | 0.485
cat sortable \| ./sortuniq2 -c > out | 1.283 | 0.676 | 1.005 | 0.611

This is the code that I made the above table with:

```
dd if=/dev/urandom of=random_sortable bs=1M count=100 >/dev/null 2>&1
cat random_sortable | tr -dc "\n[:print:]" > ascii_sortable

measure() {
        command="$1 $2 $3 > $4"
        time=$(eval "{ time $command; } 2>&1" | awk -F'[sm]' '/real/{print $2}')
        printf "| $time "
}

testcommand() {
        printf "$1 sortable $2 > out "
        measure "$1" "random_sortable" "$2" "sorted"
        measure "$1" "ascii_sortable" "$2" "sorted"
        measure "$1" "random_sortable" "$2" "/dev/null"
        measure "$1" "ascii_sortable" "$2" "/dev/null"
        printf "\n"
}

printf "command                  | random > sorted | ascii > sorted | random > null | ascii > null\n"
print  "-------------------------|-----------------|----------------|---------------|-------------\n"

testcommand "sort -u" ""
testcommand "sort" "| uniq"
testcommand "sort" "| uniq -c"
testcommand "awk '!x[\$0]++;'" ""
testcommand "cat" "| sort -u"
testcommand "cat" "| sort | uniq"
testcommand "cat" "| sort | uniq -c"
testcommand "cat" "| awk '!x[\$0]++;'"
testcommand "cat" "| ./sortuniq"
testcommand "cat" "| ./sortuniq -c"
testcommand "cat" "| ./sortuniq2"
testcommand "cat" "| ./sortuniq2 -c"

rm random_sortable
rm ascii_sortable
rm sorted
```