### PR TITLE
use STDIN constant

### DIFF
--- a/sortuniq
+++ b/sortuniq
@@ -1,8 +1,7 @@
 #!/usr/bin/php
 <?php
-$in=fopen('php://stdin',"r");
 $d=array();
-while($z=fgets($in))
+while($z=fgets(STDIN))
 	 @$d[$z]++;
 
 ob_start(null, 100000);


### PR DESCRIPTION
as of PHP 5.2.3 (released 31 May 2007, over 13 years ago, even RHEL isn't supporting 5.2 anymore), 
you can just use STDIN instead of fopen("php://stdin")

should be lil bit faster too, but when benchmarking it:
```sh
hans@xDevAd:~/test$ wget 'https://github.com/torvalds/linux/raw/v5.7/drivers/infiniband/hw/hfi1/chip.c'
--2020-08-02 10:54:11--  https://github.com/torvalds/linux/raw/v5.7/drivers/infiniband/hw/hfi1/chip.c
Resolving github.com (github.com)... 140.82.118.4
Connecting to github.com (github.com)|140.82.118.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/torvalds/linux/v5.7/drivers/infiniband/hw/hfi1/chip.c [following]
--2020-08-02 10:54:12--  https://raw.githubusercontent.com/torvalds/linux/v5.7/drivers/infiniband/hw/hfi1/chip.c
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.192.133, 151.101.128.133, 151.101.64.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.192.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 460538 (450K) [text/plain]
Saving to: ‘chip.c’

chip.c                                                              100%[===================================================================================================================================================================>] 449,74K  1,07MB/s    in 0,4s    

2020-08-02 10:54:13 (1,07 MB/s) - ‘chip.c’ saved [460538/460538]

hans@xDevAd:~/test$ wc -l chip.c 
15411 chip.c
hans@xDevAd:~/test$ wc -c chip.c 
460538 chip.c
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq1.php' > /dev/null
best time: 0.0190s best iter: 126
worst time: 0.0246s worst iter: 491

real	0m21,295s
user	0m12,737s
sys	0m11,498s
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq1.php' > /dev/null
best time: 0.0191s best iter: 698
worst time: 0.0249s worst iter: 255

real	0m21,342s
user	0m12,729s
sys	0m11,579s
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq2.php' > /dev/null
best time: 0.0192s best iter: 851
worst time: 0.0257s worst iter: 127

real	0m21,497s
user	0m12,941s
sys	0m11,550s
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq2.php' > /dev/null
best time: 0.0191s best iter: 359
worst time: 0.0303s worst iter: 571

real	0m21,451s
user	0m12,628s
sys	0m11,800s
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq1.php' > /dev/null
best time: 0.0191s best iter: 878
worst time: 0.0273s worst iter: 178

real	0m21,382s
user	0m12,812s
sys	0m11,536s
hans@xDevAd:~/test$ time shittybench 1000 'cat chip.c | php uniq2.php' > /dev/null
best time: 0.0189s best iter: 245
worst time: 0.0283s worst iter: 28

real	0m21,536s
user	0m12,892s
sys	0m11,628s
```


best fopen() time was 0.0190s, best STDIN time was 0.0189s, but seems performance is largely unaffected, on a very unscientific benchmark using a laptop that easily thermal-throttles rolling an i7-8565U laptop CPU and php 7.2.24 z.z