### PR TITLE
Add odfgrep

### DIFF
--- a/odfgrep
+++ b/odfgrep
@@ -18,7 +18,7 @@ shift
 
 for file in "$@"; do
   if [ ! -r "$file" ]; then
-    echo "odtgrep: $file: File not found"
+    echo "odfgrep: $file: File not found"
     continue
   fi
 	unzip -ca "$file" content.xml | grep -ql $flags "$term"

--- a/odtgrep
+++ b/odtgrep
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# based on https://ubuntuforums.org/showthread.php?t=899179
+
+flags=""
+if [ "$1" == "-i" ]; then
+  flags="-i"
+  shift
+fi
+
+if [ $# -lt 2 ]; then
+	echo "Usage: `basename $0` [-i] searchterm file1 [..fileN]"
+	exit 1
+fi
+
+term="$1"
+shift
+
+for file in "$@"; do
+  if [ ! -r "$file" ]; then
+    echo "odtgrep: $file: File not found"
+    continue
+  fi
+	unzip -ca "$file" content.xml | grep -ql $flags "$term"
+	if [ $? -eq 0 ]; then
+		echo "$file"
+	fi
+done


### PR DESCRIPTION
Script for listing .odt files (other OD* formats should also work) that contain text matching the pattern. Useful for when you know you wrote something, but don't know where exactly.

Usage examples:
`odtgrep "2021" contracts/*.odt`
`find -name '*.odt' -print0 | xargs -0 odtgrep -i "javascript"`

Known issues:
Does not work well with strings that are split up in multiple `<text:span>` tags due to styling.